### PR TITLE
Add support for Room, Agenda, and Date fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Your Excel file should contain these columns:
 - `Abstract of Session` - Session description
 - `Session Duration` - Duration (e.g., "20-30 minutes", "40-50 minutes")
 - `Session Level` - Level (e.g., "100 (Beginner)", "300 (Advanced)")
+- `Room` - Room number/name for the session
+- `Agenda` - Time in HHMM format (e.g., "1100" for 11:00 AM)
 
 ## Features in Detail
 
@@ -136,6 +138,8 @@ Your Excel file should contain these columns:
 - Separate counters per level for filename generation
 - Handles multiple duration options by commenting them out
 - Maps durations to standard values (30 or 60 minutes)
+- Generates ISO 8601 datetime field from event date and agenda time
+- Includes room and agenda information from data source
 
 ### Image Processing
 - Downloads from custom photo URLs first

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -16,6 +16,8 @@ This project generates Hugo templates for the AWS Community Day website based on
   - Link to photo (Optional, defaults to LinkedIn Profile)
   - Title of Session, Abstract of Session
   - Session Duration, Session Level
+  - Room (room number/name)
+  - Agenda (time in HHMM format)
   - Voter_1 through Voter_N (future use)
 
 ### Output Structure
@@ -73,11 +75,11 @@ Bio content or ""
 ---
 id: "Session_ID"
 title: "Title of Session"
-date: ""  # Empty for now
+date: "2025-09-25T11:00:00"  # Generated from event date and agenda time
 speakers:
     - "speaker-slug"
-room: ""  # Empty for now
-agenda: ""  # Empty for now
+room: "2"  # Room number/name from data source
+agenda: "1100"  # Agenda time in HHMM format from data source
 duration: "30" or "60"  # Mapped from duration string
 ---
 
@@ -125,8 +127,13 @@ SESSION_FIELD_MAPPING = {
     'title': 'Title of Session',
     'abstract': 'Abstract of Session',
     'speakers': 'Speaker Name',
-    'duration': 'Session Duration'
+    'duration': 'Session Duration',
+    'room': 'Room',
+    'agenda': 'Agenda'
 }
+
+# Event date for session datetime generation
+EVENT_DATE = "2025-09-25"
 
 LEVEL_EXTRACTION = {
     '100 (Beginner)': 1,

--- a/src/config.py
+++ b/src/config.py
@@ -18,7 +18,12 @@ SESSION_FIELD_MAPPING = {
     "abstract": "Abstract of Session",
     "speakers": "Speaker Name",
     "duration": "Session Duration",
+    "room": "Room",
+    "agenda": "Agenda",
 }
+
+# Event date for session datetime generation
+EVENT_DATE = "2025-09-25"
 
 # Session level extraction mapping
 LEVEL_EXTRACTION = {

--- a/src/data_processor.py
+++ b/src/data_processor.py
@@ -97,6 +97,8 @@ class DataProcessor:
             session_abstract = safe_get_field(row, SESSION_FIELD_MAPPING["abstract"])
             session_duration = safe_get_field(row, SESSION_FIELD_MAPPING["duration"])
             session_level = safe_get_field(row, "Session Level")
+            session_room = safe_get_field(row, SESSION_FIELD_MAPPING["room"])
+            session_agenda = safe_get_field(row, SESSION_FIELD_MAPPING["agenda"])
 
             # Validate session ID
             if not validate_session_id(session_id):
@@ -136,6 +138,8 @@ class DataProcessor:
                 "abstract": session_abstract,
                 "duration": session_duration,
                 "level": session_level,
+                "room": session_room,
+                "agenda": session_agenda,
             }
 
             speakers[email]["sessions"].append(session_data)
@@ -164,6 +168,8 @@ class DataProcessor:
                     "abstract": session["abstract"],
                     "duration": session["duration"],
                     "level": session["level"],
+                    "room": session.get("room", ""),
+                    "agenda": session.get("agenda", ""),
                     "speaker_slug": speaker_slug,
                     "speaker_name": speaker_data["name"],
                 }

--- a/src/session_generator.py
+++ b/src/session_generator.py
@@ -65,6 +65,8 @@ class SessionGenerator:
             session_abstract = session_data.get("abstract", "")
             session_duration = session_data.get("duration", "")
             speaker_slug = session_data.get("speaker_slug", "")
+            room = session_data.get("room", "")
+            agenda = session_data.get("agenda", "")
 
             # Generate markdown content
             markdown_content = self._generate_session_markdown(
@@ -73,6 +75,8 @@ class SessionGenerator:
                 session_abstract,
                 session_duration,
                 speaker_slug,
+                room,
+                agenda,
             )
 
             # Write markdown file
@@ -98,6 +102,8 @@ class SessionGenerator:
         abstract: str,
         duration: str,
         speaker_slug: str,
+        room: str = "",
+        agenda: str = "",
     ) -> str:
         """
         Generate session markdown content.
@@ -108,6 +114,8 @@ class SessionGenerator:
             abstract: Session abstract
             duration: Session duration
             speaker_slug: Speaker slug
+            room: Room number/name
+            agenda: Agenda time in HHMM format
 
         Returns:
             Formatted markdown content
@@ -115,9 +123,16 @@ class SessionGenerator:
         # Format fields
         id_field = f'id: "{session_id}"' if session_id else 'id: ""'
         title_field = f'title: "{title}"' if title else 'title: ""'
-        date_field = 'date: ""'  # Empty as specified
-        room_field = 'room: ""'  # Empty as specified
-        agenda_field = 'agenda: ""'  # Empty as specified
+
+        # Generate date field from agenda time
+        from .utils import format_session_datetime
+
+        formatted_datetime = format_session_datetime(agenda)
+        date_field = f'date: "{formatted_datetime}"' if formatted_datetime else 'date: ""'
+
+        # Format room and agenda fields
+        room_field = f'room: "{room}"' if room else 'room: ""'
+        agenda_field = f'agenda: "{agenda}"' if agenda else 'agenda: ""'
 
         # Handle speakers field
         if speaker_slug:

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,7 +6,10 @@ Contains helper functions for string sanitization, data processing, and common o
 
 import re
 import unicodedata
+from datetime import datetime
 from typing import Dict, List
+
+from .config import EVENT_DATE
 
 
 def sanitize_speaker_name(name: str) -> str:
@@ -236,3 +239,32 @@ def print_progress(current: int, total: int, item_name: str) -> None:
         item_name: Name of current item
     """
     print(f"   [{current}/{total}] {item_name}")
+
+
+def format_session_datetime(agenda_time: str) -> str:
+    """
+    Format session datetime based on event date and agenda time.
+
+    Args:
+        agenda_time: Time in HHMM format (e.g., "1100" for 11:00 AM)
+
+    Returns:
+        Formatted datetime string (YYYY-MM-DDTHH:MM:00)
+    """
+    if not agenda_time or not agenda_time.strip() or not agenda_time.isdigit():
+        return ""
+
+    try:
+        # Parse the agenda time (HHMM format)
+        hours = int(agenda_time[:2] if len(agenda_time) >= 2 else agenda_time)
+        minutes = int(agenda_time[2:]) if len(agenda_time) > 2 else 0
+
+        # Create datetime object using the event date and agenda time
+        event_date_obj = datetime.strptime(EVENT_DATE, "%Y-%m-%d")
+        session_datetime = event_date_obj.replace(hour=hours, minute=minutes)
+
+        # Format as ISO 8601 datetime string
+        return session_datetime.strftime("%Y-%m-%dT%H:%M:00")
+    except (ValueError, IndexError):
+        # Return empty string if there's any error in parsing
+        return ""


### PR DESCRIPTION
# Add support for Room, Agenda, and Date fields

## Changes Made

### 1. Added Support for Room and Agenda Fields
- Updated `config.py` to include Room and Agenda fields in the SESSION_FIELD_MAPPING
- Modified `data_processor.py` to extract these fields from the Excel data
- Updated `session_generator.py` to use these fields when generating session markdown files

### 2. Added Date Field Generation
- Added EVENT_DATE constant in `config.py` set to "2025-09-25"
- Created a new utility function `format_session_datetime()` in `utils.py` that:
  - Takes an agenda time in HHMM format (e.g., "1100")
  - Combines it with the event date
  - Formats it as an ISO 8601 datetime string (YYYY-MM-DDTHH:MM:00)
- Updated `session_generator.py` to use this function to generate the date field

## Example Output

### Before:
```yaml
id: "9cd5361f-a11e-4ded-9c36-ba35942cf66f"
title: "Serverless applications"
date: ""
speakers:
    - "jan-janssen"
room: ""
agenda: ""
duration: "60"
```

### After:
```yaml
id: "9cd5361f-a11e-4ded-9c36-ba35942cf66f"
title: "AI thing"
date: "2025-09-25T11:00:00"
speakers:
    - "frans-franssen"
room: "2"
agenda: "1100"
duration: "60"
```

## Testing
- Tested with various agenda time formats
- Verified that empty Room and Agenda fields are handled gracefully
- Confirmed that the date field is correctly formatted as ISO 8601

## Related Issue
Addresses the requirement to include Room and Agenda fields from the data source and generate a date field based on the event date and agenda time.
