### PR TITLE
feat: Add persistent session IDs and content verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Python tool to generate Hugo markdown files for AWS Community Day speakers and
 
 - **Speaker Profile Generation**: Creates individual speaker pages with bio, headline, and LinkedIn information
 - **Session File Generation**: Generates session pages with proper filename conventions (acd{level}{number}.md)
+- **Persistent Session IDs**: Maintains stable session filenames even when sessions are added or reordered
+- **Content Verification**: Updates existing files when source data changes instead of skipping them
 - **Image Processing**: Downloads and processes speaker images from LinkedIn or custom URLs, with fallback to default image
 - **Data Validation**: Handles missing data gracefully and provides detailed reporting
 - **Duplicate Handling**: Deduplicates speakers by email and handles name conflicts
@@ -26,6 +28,7 @@ A Python tool to generate Hugo markdown files for AWS Community Day speakers and
 │       ├── speakers/             # Generated speaker profiles
 │       └── sessions/             # Generated session files
 ├── data/                         # Input Excel files (gitignored)
+│   └── session_id_mapping.json   # Session ID persistence mapping
 ├── samples/                      # Default images and samples
 ├── template/                     # Reference templates
 ├── main.py                       # Main entry point
@@ -96,6 +99,7 @@ Generated in `generated_files/content/sessions/`:
 - Level 2 (Intermediate): acd201.md, acd202.md, etc.
 - Level 3 (Advanced): acd301.md, acd302.md, etc.
 - Level 4 (Expert): acd401.md, acd402.md, etc.
+- Level 5 (Principal): acd501.md, acd502.md, etc.
 
 ### Reports
 - `missing_photos.csv` - Log of image processing issues
@@ -136,6 +140,8 @@ Your Excel file should contain these columns:
 ### Session Processing
 - Sorts sessions by Session_ID for consistent ordering
 - Separate counters per level for filename generation
+- **Persistent Session IDs**: Maintains stable filenames even when sessions are reordered
+- **Content Verification**: Updates files when source data changes instead of skipping
 - Handles multiple duration options by commenting them out
 - Maps durations to standard values (30 or 60 minutes)
 - Generates ISO 8601 datetime field from event date and agenda time
@@ -177,14 +183,17 @@ Your Excel file should contain these columns:
 
 📋 Generating session files...
    ...
-   ✓ Generated 22 session files
+   ✓ Generated 18 session files
+   🔄 Updated 4 session files
+   ✓ Skipped: 2 (no changes)
 
 ==================================================
 ✅ GENERATION COMPLETE
 
 📊 SUMMARY STATISTICS:
    • Speakers processed: 17
-   • Sessions generated: 22
+   • Sessions generated: 18
+   • Sessions updated: 4
    • Images processed: 17
 
 📈 SESSIONS BY LEVEL:

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -69,6 +69,8 @@ Bio content or ""
 - Extract level number from "Session Level" (e.g., "300 (Advanced)" → 3)
 - Separate counters per level: acd{level}{counter:02d}.md
 - Examples: acd101.md, acd201.md, acd301.md, acd102.md
+- **Persistent Session IDs**: Once assigned, session IDs are preserved between runs using a mapping file
+- **Content Verification**: Existing files are checked for changes and updated if needed
 
 **Session Markdown Template**:
 ```yaml
@@ -139,9 +141,48 @@ LEVEL_EXTRACTION = {
     '100 (Beginner)': 1,
     '200 (Intermediate)': 2,
     '300 (Advanced)': 3,
-    '400 (Expert)': 4
+    '400 (Expert)': 4,
+    '500 (Principal)': 5
 }
 ```
+
+### 5. Session ID Persistence Mechanism
+
+**Purpose**:
+- Maintain stable session IDs once assigned
+- Prevent duplicate content when sessions are added or reordered
+- Allow updates to session content without changing filenames
+
+**Implementation**:
+- Store mapping between Session_IDs and assigned filenames in `data/session_id_mapping.json`
+- Track the next available number for each level
+- When generating sessions:
+  1. Check if Session_ID exists in mapping
+  2. If yes, use previously assigned filename
+  3. If no, assign next available number for that level
+
+**JSON Structure**:
+```json
+{
+  "session_id_mapping": {
+    "d4610b42-6a84-44f7-841f-564927d6ee55": "acd209",
+    "7a8b9c0d-1e2f-3g4h-5i6j-7k8l9m0n1o2p": "acd210"
+  },
+  "level_counters": {
+    "1": 5,  // Next available is acd106
+    "2": 10, // Next available is acd211
+    "3": 7,  // Next available is acd308
+    "4": 2,  // Next available is acd403
+    "5": 0   // Next available is acd501
+  }
+}
+```
+
+**Content Verification Process**:
+1. Extract key data from existing session files (room, time, title, etc.)
+2. Compare with current data from Excel source
+3. Update file if differences are detected
+4. Preserve the assigned filename
 
 ## Project Structure
 
@@ -159,6 +200,7 @@ LEVEL_EXTRACTION = {
 │       ├── speakers/
 │       └── sessions/
 ├── data/                     # Input data (gitignored)
+│   └── session_id_mapping.json # Session ID persistence mapping (gitignored)
 ├── samples/
 │   └── unknown.jpg           # Default speaker image
 ├── template/                 # Reference templates
@@ -223,14 +265,17 @@ pyyaml>=6.0
    ⚠️  Failed: 3 (logged to missing_photos.csv)
 
 📋 Generating session files...
-   ✓ Generated 23 session files
+   ✓ Generated 18 session files
+   🔄 Updated 5 session files
+   ✓ Skipped: 2 (no changes)
 
 ==================================================
 ✅ GENERATION COMPLETE
 
 📊 SUMMARY STATISTICS:
    • Speakers processed: 15
-   • Sessions generated: 23
+   • Sessions generated: 18
+   • Sessions updated: 5
    • Images downloaded: 12
    • Images failed: 3
 

--- a/main.py
+++ b/main.py
@@ -57,6 +57,8 @@ def print_summary(data_stats, speaker_stats, session_stats, image_stats, force_r
     if not force_regenerate and image_stats.get("skipped_count", 0) > 0:
         print(f"   • Speaker profiles skipped: {image_stats.get('skipped_count', 0)}")
     print(f"   • Sessions generated: {session_stats['generated_count']}")
+    if session_stats.get("updated_count", 0) > 0:
+        print(f"   • Sessions updated: {session_stats.get('updated_count', 0)}")
     print(f"   • Images processed: {image_stats['processed_count']}")
     if image_stats.get("skipped_count", 0) > 0:
         print(f"   • Images skipped: {image_stats.get('skipped_count', 0)}")
@@ -65,7 +67,7 @@ def print_summary(data_stats, speaker_stats, session_stats, image_stats, force_r
 
     # Sessions by level
     print(f"\n{EMOJIS['bar_chart']} SESSIONS BY LEVEL:")
-    level_names = {1: "Beginner", 2: "Intermediate", 3: "Advanced", 4: "Expert"}
+    level_names = {1: "Beginner", 2: "Intermediate", 3: "Advanced", 4: "Expert", 5: "Principal"}
 
     # Get level statistics from session generator
     session_gen = SessionGenerator()

--- a/src/config.py
+++ b/src/config.py
@@ -31,6 +31,7 @@ LEVEL_EXTRACTION = {
     "200 (Intermediate)": 2,
     "300 (Advanced)": 3,
     "400 (Expert)": 4,
+    "500 (Principal)": 5,
 }
 
 # Duration mapping patterns
@@ -41,6 +42,7 @@ DEFAULT_SPEAKER_IMAGE = "samples/unknown.jpg"
 EXCEL_FILE_PATH = "data/responses+votes.xlsx"
 OUTPUT_DIR = "generated_files"
 MISSING_PHOTOS_CSV = "missing_photos.csv"
+SESSION_ID_MAPPING_FILE = "data/session_id_mapping.json"
 
 # Image processing settings
 IMAGE_SIZE = (400, 400)  # Square image dimensions

--- a/src/session_generator.py
+++ b/src/session_generator.py
@@ -4,10 +4,12 @@ Session page generation module for Hugo Speaker Generator.
 Handles creation of session markdown files with proper filename generation.
 """
 
+import json
 import os
-from typing import Dict, List
+import re
+from typing import Dict, List, Tuple
 
-from .config import OUTPUT_DIR
+from .config import OUTPUT_DIR, SESSION_ID_MAPPING_FILE
 from .utils import extract_session_level, print_progress, process_multiple_durations
 
 
@@ -18,35 +20,9 @@ class SessionGenerator:
         """Initialize SessionGenerator with empty statistics."""
         self.generated_count = 0
         self.failed_count = 0
+        self.updated_count = 0
         self.session_filenames = {}
-
-    def generate_session_filenames(self, sessions: List[Dict]) -> Dict[str, str]:
-        """
-        Generate session filenames based on level and sorted by Session_ID.
-
-        Args:
-            sessions: List of session dictionaries
-
-        Returns:
-            Dictionary mapping session_id to filename
-        """
-        # Sort sessions by Session_ID for consistent ordering
-        sessions_sorted = sorted(sessions, key=lambda x: x.get("id", ""))
-
-        # Separate counters for each level
-        level_counters = {1: 0, 2: 0, 3: 0, 4: 0}
-        session_filenames = {}
-
-        for session in sessions_sorted:
-            session_id = session.get("id", "")
-            level = extract_session_level(session.get("level", ""))
-
-            level_counters[level] += 1
-            filename = f"acd{level}{level_counters[level]:02d}.md"
-            session_filenames[session_id] = filename
-
-        self.session_filenames = session_filenames
-        return session_filenames
+        self.mapping_data = self._load_session_id_mapping()
 
     def generate_session_file(self, session_data: Dict, filename: str) -> bool:
         """
@@ -163,22 +139,292 @@ class SessionGenerator:
 
         return markdown
 
-    def should_skip_session_file(self, filename: str, force_regenerate: bool = False) -> bool:
+    def get_level_statistics(self, sessions: List[Dict]) -> Dict[int, int]:
         """
-        Determine if session file generation should be skipped.
+        Get session count statistics by level.
+
+        Args:
+            sessions: List of session data
+
+        Returns:
+            Dictionary mapping level to count
+        """
+        level_counts = {1: 0, 2: 0, 3: 0, 4: 0, 5: 0}
+
+        for session in sessions:
+            level = extract_session_level(session.get("level", ""))
+            if level in level_counts:
+                level_counts[level] += 1
+
+        return level_counts
+
+    def _load_session_id_mapping(self) -> Dict:
+        """
+        Load session ID mapping from JSON file.
+
+        Returns:
+            Dictionary with mapping data or default structure if file doesn't exist
+        """
+        default_mapping = {
+            "session_id_mapping": {},
+            "level_counters": {"1": 0, "2": 0, "3": 0, "4": 0, "5": 0},
+        }
+
+        try:
+            if os.path.exists(SESSION_ID_MAPPING_FILE):
+                with open(SESSION_ID_MAPPING_FILE, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            else:
+                # Create directory if it doesn't exist
+                os.makedirs(os.path.dirname(SESSION_ID_MAPPING_FILE), exist_ok=True)
+                return default_mapping
+        except Exception as e:
+            print(f"   ⚠️  Failed to load session ID mapping: {str(e)}")
+            return default_mapping
+
+    def _save_session_id_mapping(self) -> bool:
+        """
+        Save session ID mapping to JSON file.
+
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            with open(SESSION_ID_MAPPING_FILE, "w", encoding="utf-8") as f:
+                json.dump(self.mapping_data, f, indent=2)
+            return True
+        except Exception as e:
+            print(f"   ⚠️  Failed to save session ID mapping: {str(e)}")
+            return False
+
+    def _extract_session_data_from_file(self, filepath: str) -> Dict:
+        """
+        Extract session data from an existing markdown file.
+
+        Args:
+            filepath: Path to the session markdown file
+
+        Returns:
+            Dictionary with extracted session data
+        """
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            # Extract frontmatter between --- markers
+            frontmatter_match = re.search(r"---\s+(.*?)\s+---", content, re.DOTALL)
+            if not frontmatter_match:
+                return {}
+
+            frontmatter = frontmatter_match.group(1)
+
+            # Extract key fields
+            session_data = {}
+
+            # Extract session ID
+            id_match = re.search(r'id:\s*"([^"]*)"', frontmatter)
+            if id_match:
+                session_data["id"] = id_match.group(1)
+
+            # Extract room
+            room_match = re.search(r'room:\s*"([^"]*)"', frontmatter)
+            if room_match:
+                session_data["room"] = room_match.group(1)
+
+            # Extract agenda time
+            agenda_match = re.search(r'agenda:\s*"([^"]*)"', frontmatter)
+            if agenda_match:
+                session_data["agenda"] = agenda_match.group(1)
+
+            # Extract title
+            title_match = re.search(r'title:\s*"([^"]*)"', frontmatter)
+            if title_match:
+                session_data["title"] = title_match.group(1)
+
+            # Extract speaker slug
+            speaker_match = re.search(r'speakers:\s*\n\s*-\s*"([^"]*)"', frontmatter)
+            if speaker_match:
+                session_data["speaker_slug"] = speaker_match.group(1)
+
+            # Extract abstract (content after frontmatter)
+            abstract_match = re.search(r"---\s+(.*?)\s+---(.*)", content, re.DOTALL)
+            if abstract_match:
+                session_data["abstract"] = abstract_match.group(2).strip()
+
+            return session_data
+
+        except Exception as e:
+            print(f"   ⚠️  Failed to extract data from {filepath}: {str(e)}")
+            return {}
+
+    def _session_needs_update(self, session_data: Dict, existing_data: Dict) -> bool:
+        """
+        Check if session data has changed and needs updating.
+
+        Args:
+            session_data: Current session data from source
+            existing_data: Existing session data from file
+
+        Returns:
+            True if update is needed, False otherwise
+        """
+        # Check key fields that would require an update
+        fields_to_check = ["title", "room", "agenda", "speaker_slug", "abstract"]
+
+        for field in fields_to_check:
+            current_value = session_data.get(field, "")
+            existing_value = existing_data.get(field, "")
+
+            # If any field is different, update is needed
+            if current_value != existing_value:
+                return True
+
+        return False
+
+    def generate_session_filenames(self, sessions: List[Dict]) -> Dict[str, str]:
+        """
+        Generate session filenames based on level and persistent mapping.
+
+        Args:
+            sessions: List of session dictionaries
+
+        Returns:
+            Dictionary mapping session_id to filename
+        """
+        session_filenames = {}
+        session_id_mapping = self.mapping_data.get("session_id_mapping", {})
+        level_counters = {
+            1: int(self.mapping_data.get("level_counters", {}).get("1", 0)),
+            2: int(self.mapping_data.get("level_counters", {}).get("2", 0)),
+            3: int(self.mapping_data.get("level_counters", {}).get("3", 0)),
+            4: int(self.mapping_data.get("level_counters", {}).get("4", 0)),
+            5: int(self.mapping_data.get("level_counters", {}).get("5", 0)),
+        }
+
+        # First, assign filenames to sessions that already have mappings
+        for session in sessions:
+            session_id = session.get("id", "")
+            if not session_id:
+                continue
+
+            # If this session already has a mapping, use it
+            if session_id in session_id_mapping:
+                base_filename = session_id_mapping[session_id]
+                # Ensure the filename has the .md extension
+                filename = (
+                    f"{base_filename}.md" if not base_filename.endswith(".md") else base_filename
+                )
+                session_filenames[session_id] = filename
+
+        # Then, assign filenames to new sessions
+        for session in sessions:
+            session_id = session.get("id", "")
+            if not session_id or session_id in session_filenames:
+                continue
+
+            # This is a new session, assign a new filename
+            level = extract_session_level(session.get("level", ""))
+            level_counters[level] += 1
+            base_filename = f"acd{level}{level_counters[level]:02d}"
+            filename = f"{base_filename}.md"
+
+            # Add to mappings
+            session_filenames[session_id] = filename
+            session_id_mapping[session_id] = base_filename  # Store without extension
+
+        # Update the mapping data
+        self.mapping_data["session_id_mapping"] = session_id_mapping
+        self.mapping_data["level_counters"] = {
+            "1": level_counters[1],
+            "2": level_counters[2],
+            "3": level_counters[3],
+            "4": level_counters[4],
+            "5": level_counters[5],
+        }
+
+        # Save the updated mapping
+        self._save_session_id_mapping()
+
+        self.session_filenames = session_filenames
+        return session_filenames
+
+    def should_skip_session_file(
+        self, filename: str, session_data: Dict, force_regenerate: bool = False
+    ) -> Tuple[bool, bool]:
+        """
+        Determine if session file generation should be skipped or updated.
 
         Args:
             filename: Session filename
+            session_data: Current session data
             force_regenerate: If True, never skip
 
         Returns:
-            True if should skip, False if should generate
+            Tuple of (should_skip, should_update)
         """
         if force_regenerate:
-            return False
+            return False, False
 
         session_path = os.path.join(OUTPUT_DIR, "content", "sessions", filename)
-        return os.path.exists(session_path)
+
+        # If file doesn't exist, don't skip (need to generate)
+        if not os.path.exists(session_path):
+            return False, False
+
+        # File exists, check if it needs updating
+        existing_data = self._extract_session_data_from_file(session_path)
+        needs_update = self._session_needs_update(session_data, existing_data)
+
+        # If needs update, don't skip but mark for update
+        if needs_update:
+            return False, True
+
+        # Otherwise, skip (file exists and doesn't need updating)
+        return True, False
+
+    def update_session_file(self, session_data: Dict, filename: str) -> bool:
+        """
+        Update an existing session file with new data.
+
+        Args:
+            session_data: Dictionary containing session information
+            filename: Target filename for the session
+
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            # Generate new markdown content
+            session_id = session_data.get("id", "")
+            session_title = session_data.get("title", "")
+            session_abstract = session_data.get("abstract", "")
+            session_duration = session_data.get("duration", "")
+            speaker_slug = session_data.get("speaker_slug", "")
+            room = session_data.get("room", "")
+            agenda = session_data.get("agenda", "")
+
+            markdown_content = self._generate_session_markdown(
+                session_id,
+                session_title,
+                session_abstract,
+                session_duration,
+                speaker_slug,
+                room,
+                agenda,
+            )
+
+            # Write updated markdown file
+            session_path = os.path.join(OUTPUT_DIR, "content", "sessions", filename)
+            with open(session_path, "w", encoding="utf-8") as f:
+                f.write(markdown_content)
+
+            self.updated_count += 1
+            return True
+
+        except Exception as e:
+            print(f"   ⚠️  Failed to update session file {filename}: {str(e)}")
+            self.failed_count += 1
+            return False
 
     def generate_all_session_files(
         self, sessions: List[Dict], force_regenerate: bool = False
@@ -198,23 +444,42 @@ class SessionGenerator:
         if force_regenerate:
             print("   🔄 Force regeneration enabled - rebuilding all session files")
 
-        # Generate filenames first
+        # Generate filenames first (using persistent mapping)
         session_filenames = self.generate_session_filenames(sessions)
 
         total_sessions = len(sessions)
         current = 0
         skipped_count = 0
+        updated_count = 0
 
         for session in sessions:
             current += 1
             session_id = session.get("id", "")
             session_title = session.get("title", "Unknown Session")
-            filename = session_filenames.get(session_id, f"unknown-{current}.md")
 
-            # Check if we should skip this session file
-            if self.should_skip_session_file(filename, force_regenerate):
-                print_progress(current, total_sessions, f"✓ Skipped: {filename} (already exists)")
+            if not session_id or session_id not in session_filenames:
+                print_progress(
+                    current, total_sessions, f"⚠️ Skipped: Invalid session ID for {session_title}"
+                )
+                self.failed_count += 1
+                continue
+
+            filename = session_filenames[session_id]
+
+            # Check if we should skip or update this session file
+            should_skip, should_update = self.should_skip_session_file(
+                filename, session, force_regenerate
+            )
+
+            if should_skip:
+                print_progress(current, total_sessions, f"✓ Skipped: {filename} (no changes)")
                 skipped_count += 1
+            elif should_update:
+                print_progress(
+                    current, total_sessions, f"🔄 Updating: {filename} - {session_title}"
+                )
+                self.update_session_file(session, filename)
+                updated_count += 1
             else:
                 if force_regenerate:
                     print_progress(
@@ -223,35 +488,21 @@ class SessionGenerator:
                         f"🔄 Force regenerating: {filename} - {session_title}",
                     )
                 else:
-                    print_progress(current, total_sessions, f"{filename} - {session_title}")
+                    print_progress(
+                        current, total_sessions, f"📝 Generating: {filename} - {session_title}"
+                    )
 
                 self.generate_session_file(session, filename)
 
         print(f"   ✓ Generated {self.generated_count} session files")
+        if updated_count > 0:
+            print(f"   🔄 Updated {updated_count} session files")
         if skipped_count > 0:
-            print(f"   ✓ Skipped: {skipped_count}")
+            print(f"   ✓ Skipped: {skipped_count} (no changes)")
         if self.failed_count > 0:
             print(f"   ⚠️  Failed: {self.failed_count}")
 
         return self.get_statistics()
-
-    def get_level_statistics(self, sessions: List[Dict]) -> Dict[int, int]:
-        """
-        Get session count statistics by level.
-
-        Args:
-            sessions: List of session data
-
-        Returns:
-            Dictionary mapping level to count
-        """
-        level_counts = {1: 0, 2: 0, 3: 0, 4: 0}
-
-        for session in sessions:
-            level = extract_session_level(session.get("level", ""))
-            level_counts[level] += 1
-
-        return level_counts
 
     def get_statistics(self) -> Dict:
         """
@@ -262,6 +513,7 @@ class SessionGenerator:
         """
         return {
             "generated_count": self.generated_count,
+            "updated_count": self.updated_count,
             "failed_count": self.failed_count,
             "session_filenames": self.session_filenames,
         }

--- a/src/utils.py
+++ b/src/utils.py
@@ -73,7 +73,7 @@ def extract_session_level(level_string: str) -> int:
         level_string: e.g., "300 (Advanced)"
 
     Returns:
-        Numeric level (1-4), defaults to 2 if not found
+        Numeric level (1-5), defaults to 2 if not found
     """
     if not level_string:
         return 2  # Default to intermediate
@@ -82,7 +82,9 @@ def extract_session_level(level_string: str) -> int:
     match = re.search(r"(\d+)", level_string)
     if match:
         level_num = int(match.group(1))
-        if level_num >= 400:
+        if level_num >= 500:
+            return 5
+        elif level_num >= 400:
             return 4
         elif level_num >= 300:
             return 3


### PR DESCRIPTION
## Changes

- Implement persistent session ID mapping to maintain stable filenames
- Add content verification to update files when source data changes
- Add support for level 500 sessions
- Fix duplicate should_skip_session_file method
- Update documentation to reflect changes

## Problem Solved

1. When a room or time gets changed, the session is now updated instead of skipped
2. When a new session is added, existing sessions maintain their IDs
3. Added support for level 500 sessions for future use

## Implementation Details

- Created a JSON-based mapping system stored in data/session_id_mapping.json
- Added content verification to detect and update changed sessions
- Fixed file extension handling in the persistent mapping
- Removed duplicate method definitions