### PR TITLE
fix: add duration field to session update detection

### DIFF
--- a/src/session_generator.py
+++ b/src/session_generator.py
@@ -303,6 +303,11 @@ class SessionGenerator:
                 if sponsor_slugs:
                     session_data["sponsor_slugs"] = sponsor_slugs
 
+            # Extract duration
+            duration_match = re.search(r'duration:\s*"([^"]*)"', frontmatter)
+            if duration_match:
+                session_data["duration"] = duration_match.group(1)
+
             # Extract abstract (content after frontmatter)
             abstract_match = re.search(r"---\s+(.*?)\s+---(.*)", content, re.DOTALL)
             if abstract_match:
@@ -326,7 +331,7 @@ class SessionGenerator:
             True if update is needed, False otherwise
         """
         # Check key fields that would require an update
-        fields_to_check = ["title", "room", "agenda", "abstract"]
+        fields_to_check = ["title", "room", "agenda", "abstract", "duration"]
 
         for field in fields_to_check:
             current_value = session_data.get(field, "")


### PR DESCRIPTION
- Add duration extraction from existing markdown files in _extract_session_data_from_file()
- Include 'duration' in fields_to_check list in _session_needs_update()
- Session files now properly update when duration changes in Excel data
- Fixes issue where duration changes (e.g., 60 to 30 minutes) were not detected
- Ensures all session fields are properly monitored for changes

Tested: acd310 duration change from 60 to 30 now triggers file update